### PR TITLE
add preagg feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ INSTALL
 .dirstamp
 statsd-proxy
 configure
+configure.lineno

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,6 +7,7 @@ statsd_proxy_SOURCES=src/buf.c \
 					 src/ketama.c \
 					 src/log.c \
 					 src/md5.c \
+					 src/preagg.c \
 					 src/parser.c \
 					 src/proxy.c \
 					 src/statsd-proxy.c

--- a/agg.cfg
+++ b/agg.cfg
@@ -1,3 +1,0 @@
-remove metric.test.r metric.test.hello
-copy metric.test. metric.test.world
-

--- a/agg.cfg
+++ b/agg.cfg
@@ -1,0 +1,3 @@
+remove metric.test.r metric.test.hello
+copy metric.test. metric.test.world
+

--- a/src/config.c
+++ b/src/config.c
@@ -48,7 +48,6 @@ void config_free(struct config *c) {
 
 int config_init(struct config *c, const char *filename) {
     assert(c != NULL);
-
     struct buf *buf = buf_new(NULL);
 
     /* Read config file */
@@ -150,6 +149,19 @@ int config_init(struct config *c, const char *filename) {
             c->num_nodes++;
             log_debug("load config.node#%d udp://%s:%hu:%u", c->num_nodes, host,
                       port, weight);
+        }
+
+        if (strncmp("rule", cfg.key, cfg.key_len) == 0) {
+            int errn = parse_preagg_rules(&PREAGG_RULES, cfg.val, cfg.val_len);
+            if (errn != AGG_OK) {
+              log_error("invalid rule at line %d", cfg.lineno);
+              return CONFIG_EVALUE;
+            }
+            log_debug("load config.rule#%d %s->%s",
+                      cfg.lineno,
+                      PREAGG_RULES.rules[PREAGG_RULES.rules_num].prefix,
+                      PREAGG_RULES.rules[PREAGG_RULES.rules_num].to);
+            PREAGG_RULES.rules_num++;
         }
     }
 

--- a/src/config.h
+++ b/src/config.h
@@ -9,6 +9,7 @@
 
 #include <unistd.h>
 #include "ketama.h"
+#include "preagg.h"
 
 #define KETAMA_NUM_NODES_MAX 1024
 #define KETAMA_NODE_KEY_LEN_MAX 32

--- a/src/preagg.c
+++ b/src/preagg.c
@@ -1,0 +1,122 @@
+#include "preagg.h"
+
+void load_preagg_rules(char *file, struct agg_rules *rules) {
+  rules->rules = malloc(sizeof(struct agg_rule) * MAX_AGG_RULE_NUM);
+  rules->rules_num = 0;
+  FILE *fp;
+  if ((fp = fopen(file, "r")) == NULL) {
+    log_warn("pre aggregator config file not found");
+    return;
+  }
+
+  size_t now_pos = 0;
+  char prefix[MAX_KEY_LENGTH] = {};
+  char to[MAX_KEY_LENGTH] = {};
+  char rule_type[MAX_RULE_TYPE_LENGTH] = {};
+  memset(prefix, '\0', MAX_KEY_LENGTH);
+  memset(to, '\0', MAX_KEY_LENGTH);
+  memset(rule_type, '\0', MAX_RULE_TYPE_LENGTH);
+  log_debug("read config file %s", file);
+
+  while (fscanf(fp, "%s %s %s", rule_type, prefix, to) != EOF) {
+    size_t len_prefix = strlen(prefix);
+    size_t len_to = strlen(prefix);
+    size_t len_type = strlen(rule_type);
+    char *prefix_cpy = malloc(len_prefix);
+    char *to_cpy = malloc(len_to);
+    memmove(prefix_cpy, prefix, len_prefix);
+    memmove(to_cpy, to, len_to);
+    struct agg_rule *rule = malloc(sizeof(struct agg_rule));
+    rule->prefix = prefix_cpy;
+    rule->prefix_len = len_prefix;
+    rule->to = to_cpy;
+    rule->to_len = len_to;
+    if (len_type != 0) {
+      switch (rule_type[0]) {
+        case 'r':
+          rule->rule_type = AGG_REMOVE;
+          break;
+        case 'c':
+        default:
+          rule->rule_type = AGG_COPY;
+      }
+    } else {
+      log_warn("Invalidate Rule Type");
+      continue;
+    }
+
+    rules->rules[now_pos++] = rule;
+
+    memset(rule_type, '\0', len_type);
+    memset(prefix, '\0', len_prefix);
+    memset(to, '\0', len_to);
+  }
+  rules->rules_num = now_pos;
+
+  free(prefix);
+  free(to);
+  fclose(fp);
+}
+
+size_t is_prefix(const char *str1, size_t len_str1, const char *str2,
+                 size_t len_str2);
+
+int preagg(struct parser_result *result, struct parser_result *out_result) {
+  size_t i = 0;
+  for (; i < PREAGG_RULES.rules_num; i++) {
+    struct agg_rule *rule = PREAGG_RULES.rules[i];
+    if (result->len < rule->prefix_len) continue;
+    // to find out if  there have the special prefix
+    size_t pos =
+        is_prefix(rule->prefix, rule->prefix_len, result->key, result->len);
+    if (!pos) continue;
+
+    size_t left_blen = result->blen - pos;
+    size_t alloc_blen = rule->to_len + left_blen;
+    char *blk = malloc(alloc_blen);
+    memcpy(blk, rule->to, rule->to_len);
+    memcpy(&blk[rule->to_len], &result->block[pos], left_blen);
+
+    size_t left_len = result->len - 1 - pos;
+    size_t key_len = rule->to_len + left_len;
+
+    out_result->block = blk;
+    out_result->blen = alloc_blen;
+    out_result->key = blk;
+    out_result->len = key_len;
+    return rule->rule_type;
+  }
+
+  return AGG_NOAGG;
+}
+
+/*
+ * Return the pos where should we substr if  str1 is the prefix of str2
+ * Return 0 if  len_str2 < len_str1 or str1 is not the prefix of str2
+ */
+size_t is_prefix(const char *str1, size_t len_str1, const char *str2,
+                 size_t len_str2) {
+  if (len_str2 < len_str1) return 0;
+  size_t pos = 0;
+  size_t matched = 0;
+  for (; pos < len_str1; ++pos) {
+    if (str1[pos] != str2[pos]) return 0;
+    ++matched;
+  }
+
+  size_t next_dot_pos = matched;
+  // find next dot and exclude it
+  pos = matched;
+  while (pos < len_str2) {
+    if (str2[pos] == '.') {
+      next_dot_pos = pos;
+      break;
+    }
+    ++pos;
+  }
+
+  if (next_dot_pos == matched) {
+    return len_str2 - 1;
+  }
+  return next_dot_pos;
+}

--- a/src/preagg.c
+++ b/src/preagg.c
@@ -1,61 +1,67 @@
 #include "preagg.h"
 
-void load_preagg_rules(char *file, struct agg_rules *rules) {
-  rules->rules = malloc(sizeof(struct agg_rule) * MAX_AGG_RULE_NUM);
-  rules->rules_num = 0;
-  FILE *fp;
-  if ((fp = fopen(file, "r")) == NULL) {
-    log_warn("pre aggregator config file not found");
-    return;
-  }
+enum {
+  RULE_STATE_START  = 0,
+  RULE_STATE_TYPE   = 1,
+  RULE_STATE_PREFIX = 2,
+  RULE_STATE_SUFFIX = 3,
+  RULE_STATE_SPLIT  = 4,
+};
 
-  size_t now_pos = 0;
-  char prefix[MAX_KEY_LENGTH] = {};
-  char to[MAX_KEY_LENGTH] = {};
-  char rule_type[MAX_RULE_TYPE_LENGTH] = {};
-  memset(prefix, '\0', MAX_KEY_LENGTH);
-  memset(to, '\0', MAX_KEY_LENGTH);
-  memset(rule_type, '\0', MAX_RULE_TYPE_LENGTH);
-  log_debug("read config file %s", file);
 
-  while (fscanf(fp, "%s %s %s", rule_type, prefix, to) != EOF) {
-    size_t len_prefix = strlen(prefix);
-    size_t len_to = strlen(prefix);
-    size_t len_type = strlen(rule_type);
-    char *prefix_cpy = malloc(len_prefix);
-    char *to_cpy = malloc(len_to);
-    memmove(prefix_cpy, prefix, len_prefix);
-    memmove(to_cpy, to, len_to);
-    struct agg_rule *rule = malloc(sizeof(struct agg_rule));
-    rule->prefix = prefix_cpy;
-    rule->prefix_len = len_prefix;
-    rule->to = to_cpy;
-    rule->to_len = len_to;
-    if (len_type != 0) {
-      switch (rule_type[0]) {
-        case 'r':
-          rule->rule_type = AGG_REMOVE;
-          break;
-        case 'c':
-        default:
-          rule->rule_type = AGG_COPY;
+int parse_preagg_rules(struct agg_rules *rules, const char* value, size_t value_len) {
+  int state = RULE_STATE_START;
+  size_t pos = 0, mark = 0;
+  struct agg_rule rule;
+  while(pos < value_len) {
+    switch(state){
+    case RULE_STATE_START:
+      state = RULE_STATE_TYPE;
+      break;
+    case RULE_STATE_SPLIT:
+      state = RULE_STATE_TYPE;
+      if (state == RULE_STATE_TYPE) {
+        state = RULE_STATE_PREFIX;
+        mark = pos+1;
+        if (strncmp("remove", value, AGG_REMOVE_LEN) ) {
+          rule.rule_type = AGG_REMOVE;
+        } else if (strncmp("copy", value, AGG_COPY_LEN)) {
+          rule.rule_type = AGG_COPY;
+        } else {
+          return AGG_ETYPE;
+        }
+      } else if (state == RULE_STATE_PREFIX) {
+        state = RULE_STATE_SUFFIX;
+        mark = pos + 1;
+        rule.prefix_len = pos-mark;
+        rule.prefix = malloc(rule.prefix_len);
+        memcpy(&rule.prefix, &value[mark], rule.prefix_len);
+      } else {
+        return AGG_ESPLIT;
       }
-    } else {
-      log_warn("Invalidate Rule Type");
-      continue;
+      break;
     }
-
-    rules->rules[now_pos++] = rule;
-
-    memset(rule_type, '\0', len_type);
-    memset(prefix, '\0', len_prefix);
-    memset(to, '\0', len_to);
   }
-  rules->rules_num = now_pos;
 
-  free(prefix);
-  free(to);
-  fclose(fp);
+  if (pos > mark) {
+    rule.to_len = pos - mark;
+    rule.to = malloc(rule.to_len);
+    memcpy(rule.to, &value[mark], rule.to_len);
+  } else if (pos == mark) {
+    rule.to_len = rule.prefix_len;
+    rule.to = malloc(rule.prefix_len);
+    memcpy(rule.to, rule.prefix, rule.prefix_len);
+  } else {
+    // Unreachable, but deal it for excaption;
+    return AGG_ECONF;
+  }
+
+  if (rules->rules_num > MAX_AGG_RULE_NUM) {
+    return AGG_ETOOMUCH;
+  }
+
+  memcpy(&rules->rules[rules->rules_num], &rule, sizeof(struct agg_rule));
+  return AGG_OK;
 }
 
 size_t is_prefix(const char *str1, size_t len_str1, const char *str2,
@@ -64,27 +70,27 @@ size_t is_prefix(const char *str1, size_t len_str1, const char *str2,
 int preagg(struct parser_result *result, struct parser_result *out_result) {
   size_t i = 0;
   for (; i < PREAGG_RULES.rules_num; i++) {
-    struct agg_rule *rule = PREAGG_RULES.rules[i];
-    if (result->len < rule->prefix_len) continue;
+    struct agg_rule rule = PREAGG_RULES.rules[i];
+    if (result->len < rule.prefix_len) continue;
     // to find out if  there have the special prefix
     size_t pos =
-        is_prefix(rule->prefix, rule->prefix_len, result->key, result->len);
+        is_prefix(rule.prefix, rule.prefix_len, result->key, result->len);
     if (!pos) continue;
 
     size_t left_blen = result->blen - pos;
-    size_t alloc_blen = rule->to_len + left_blen;
+    size_t alloc_blen = rule.to_len + left_blen;
     char *blk = malloc(alloc_blen);
-    memcpy(blk, rule->to, rule->to_len);
-    memcpy(&blk[rule->to_len], &result->block[pos], left_blen);
+    memcpy(blk, rule.to, rule.to_len);
+    memcpy(&blk[rule.to_len], &result->block[pos], left_blen);
 
     size_t left_len = result->len - 1 - pos;
-    size_t key_len = rule->to_len + left_len;
+    size_t key_len = rule.to_len + left_len;
 
     out_result->block = blk;
     out_result->blen = alloc_blen;
     out_result->key = blk;
     out_result->len = key_len;
-    return rule->rule_type;
+    return rule.rule_type;
   }
 
   return AGG_NOAGG;

--- a/src/preagg.h
+++ b/src/preagg.h
@@ -12,6 +12,8 @@
 #define MAX_AGG_RULE_NUM 1024
 #define MAX_KEY_LENGTH 1024 * 16
 #define MAX_RULE_TYPE_LENGTH 10
+#define AGG_COPY_LEN 4
+#define AGG_REMOVE_LEN 5
 
 enum {
   AGG_OK = 0,            // operation is ok
@@ -21,6 +23,9 @@ enum {
 
   AGG_REMOVE = 4,  // Remove originnal stream
   AGG_COPY = 5,  // Default Operation, copy and throw a new parse_result object
+  AGG_ETYPE = 6,
+  AGG_ESPLIT = 7,
+  AGG_ETOOMUCH = 8,
 };
 
 struct agg_rule {
@@ -32,13 +37,13 @@ struct agg_rule {
 };
 
 struct agg_rules {
-  struct agg_rule **rules;
+  struct agg_rule rules[MAX_AGG_RULE_NUM] ;
   size_t rules_num;
 };
 
 struct agg_rules PREAGG_RULES;
 
-void load_preagg_rules(char *file, struct agg_rules *rules);
+int parse_preagg_rules(struct agg_rules *rules, const char* value, size_t value_len) ;
 
 int preagg(struct parser_result *result, struct parser_result *out_result);
 

--- a/src/preagg.h
+++ b/src/preagg.h
@@ -1,0 +1,45 @@
+// Copyright (C) 2016 by wayslog
+
+#ifndef _CW_PREAGG_H
+#define _CW_PREAGG_H
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "log.h"
+#include "parser.h"
+
+// test is_prefix, if matched, replace with "to" till next dot
+#define MAX_AGG_RULE_NUM 1024
+#define MAX_KEY_LENGTH 1024 * 16
+#define MAX_RULE_TYPE_LENGTH 10
+
+enum {
+  AGG_OK = 0,            // operation is ok
+  AGG_NOAGG = 1,         // No need to agg
+  AGG_ECONF = 2,         // CONFIG parse error
+  AGG_ECFGNOTFOUND = 3,  // config file not found
+
+  AGG_REMOVE = 4,  // Remove originnal stream
+  AGG_COPY = 5,  // Default Operation, copy and throw a new parse_result object
+};
+
+struct agg_rule {
+  char *prefix;
+  size_t prefix_len;
+  char *to;
+  size_t to_len;
+  int rule_type;
+};
+
+struct agg_rules {
+  struct agg_rule **rules;
+  size_t rules_num;
+};
+
+struct agg_rules PREAGG_RULES;
+
+void load_preagg_rules(char *file, struct agg_rules *rules);
+
+int preagg(struct parser_result *result, struct parser_result *out_result);
+
+#endif

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -17,8 +17,7 @@
 #include "parser.h"
 #include "preagg.h"
 
-int
-send_to_buf ( struct ctx *ctx, struct parser_result *result, struct buf *sbuf);
+int send_to_buf ( struct ctx *ctx, struct parser_result *result, struct buf *sbuf);
 /* Start proxy in a thread. */
 void *thread_start(void *arg) {
     struct ctx *ctx = arg;

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -15,7 +15,10 @@
 #include "ketama.h"
 #include "log.h"
 #include "parser.h"
+#include "preagg.h"
 
+int
+send_to_buf ( struct ctx *ctx, struct parser_result *result, struct buf *sbuf);
 /* Start proxy in a thread. */
 void *thread_start(void *arg) {
     struct ctx *ctx = arg;
@@ -126,28 +129,30 @@ int relay_buf(struct ctx *ctx) {
     if (ctx->buf->len == 0) return PROXY_OK;
 
     struct parser_result result;
+    struct parser_result agg_result;
     int n, n_parsed = 0;
     char *data = ctx->buf->data;
     size_t len = ctx->buf->len;
-    struct ketama_node *node;
-    struct sockaddr_in addr;
     struct buf *sbuf = NULL;
-
+    int errn = 0;
     while ((n = parse(&result, data, len)) > 0) {
-        node = ketama_node_iget(ctx->ring, result.key, result.len);
+        // send the result to buf
+        int ret = preagg(&result, &agg_result) ;
+        if (ret != AGG_NOAGG) {
+            errn = send_to_buf(ctx, &agg_result, sbuf);
+            free(agg_result.block);
+            agg_result.block = NULL;
+            agg_result.key = NULL;
+            agg_result.len = 0;
+            agg_result.blen = 0;
+            if (errn != PROXY_OK)
+                return errn;
 
-        sbuf = ctx->sbufs[node->idx];
-        addr = ctx->addrs[node->idx];
-
-        if (sbuf->len > 0 && buf_putc(sbuf, '\n') != BUF_OK)
-            return PROXY_ENOMEM;
-
-        if (buf_put(sbuf, result.block, result.blen) != BUF_OK)
-            return PROXY_ENOMEM;
-
-        /* flush buffer if this buf is large enough */
-        if (sbuf->len >= BUF_SEND_UNIT) send_buf(ctx, addr, sbuf, node->key);
-
+            if (ret != AGG_REMOVE) {
+                if ((errn = send_to_buf(ctx, &result, sbuf) ) != PROXY_OK)
+                    return errn;
+            }
+        }
         data += n;
         len -= n;
         n_parsed += n;
@@ -155,6 +160,26 @@ int relay_buf(struct ctx *ctx) {
 
     buf_lrm(ctx->buf, n_parsed);
     return PROXY_OK;
+}
+
+int send_to_buf (struct ctx *ctx, struct parser_result *result, struct buf *sbuf) {
+  struct ketama_node *node;
+  struct sockaddr_in addr;
+  node = ketama_node_iget(ctx->ring, result->key, result->len);
+
+  sbuf = ctx->sbufs[node->idx];
+  addr = ctx->addrs[node->idx];
+
+
+  if (sbuf->len > 0 && buf_putc(sbuf, '\n') != BUF_OK)
+    return PROXY_ENOMEM;
+
+  if (buf_put(sbuf, result->block, result->blen) != BUF_OK)
+    return PROXY_ENOMEM;
+
+  /* flush buffer if this buf is large enough */
+  if (sbuf->len >= BUF_SEND_UNIT) send_buf(ctx, addr, sbuf, node->key);
+  return PROXY_OK;
 }
 
 /* Flush buffers on interval. */

--- a/src/statsd-proxy.c
+++ b/src/statsd-proxy.c
@@ -18,7 +18,6 @@
 #include "proxy.h"
 
 #include "config.h"
-#include "preagg.h"
 
 #define STATSD_PROXY_VERSION "0.1.0"
 
@@ -30,14 +29,12 @@ int main(int argc, char *argv[]) {
     log_open("statsd-proxy", NULL, 0);
 
     char *filename;
-    char *aggfilename;
 
-    const char *short_opt = "hvdp:f:";
+    const char *short_opt = "hvdf:";
     struct option long_opt[] = {
         {"help", no_argument, NULL, 'h'},
         {"version", no_argument, NULL, 'v'},
         {"debug", no_argument, NULL, 'd'},
-        {"preagg", required_argument, NULL, 'p'},
         {"file", required_argument, NULL, 'f'},
         {NULL, 0, NULL, 0},
     };
@@ -56,9 +53,6 @@ int main(int argc, char *argv[]) {
             case 'f':
                 filename = optarg;
                 break;
-            case 'p':
-                aggfilename = optarg;
-                break;
             case 'd':
                 log_setlevel(LOG_DEBUG);
                 break;
@@ -69,7 +63,6 @@ int main(int argc, char *argv[]) {
 
     if (argc == 1 || optind < argc) usage();
 
-    load_preagg_rules(aggfilename, &PREAGG_RULES);
     struct config *config = config_new();
 
     if (config == NULL) exit(1);
@@ -95,7 +88,6 @@ void usage(void) {
     fprintf(stderr, "  -h, --help            Show this message\n");
     fprintf(stderr, "  -v, --version         Show version\n");
     fprintf(stderr, "  -d, --debug           Enable debug logging\n");
-    fprintf(stderr, "  -p, --preagg agg.fg   Preagg config file\n");
     fprintf(stderr, "Copyright (c) https://github.com/hit9/statsd-proxy\n");
     exit(1);
 }

--- a/src/statsd-proxy.c
+++ b/src/statsd-proxy.c
@@ -18,6 +18,7 @@
 #include "proxy.h"
 
 #include "config.h"
+#include "preagg.h"
 
 #define STATSD_PROXY_VERSION "0.1.0"
 
@@ -29,12 +30,14 @@ int main(int argc, char *argv[]) {
     log_open("statsd-proxy", NULL, 0);
 
     char *filename;
+    char *aggfilename;
 
-    const char *short_opt = "hvdf:";
+    const char *short_opt = "hvdp:f:";
     struct option long_opt[] = {
         {"help", no_argument, NULL, 'h'},
         {"version", no_argument, NULL, 'v'},
         {"debug", no_argument, NULL, 'd'},
+        {"preagg", required_argument, NULL, 'p'},
         {"file", required_argument, NULL, 'f'},
         {NULL, 0, NULL, 0},
     };
@@ -53,6 +56,9 @@ int main(int argc, char *argv[]) {
             case 'f':
                 filename = optarg;
                 break;
+            case 'p':
+                aggfilename = optarg;
+                break;
             case 'd':
                 log_setlevel(LOG_DEBUG);
                 break;
@@ -63,6 +69,7 @@ int main(int argc, char *argv[]) {
 
     if (argc == 1 || optind < argc) usage();
 
+    load_preagg_rules(aggfilename, &PREAGG_RULES);
     struct config *config = config_new();
 
     if (config == NULL) exit(1);
@@ -85,9 +92,10 @@ void usage(void) {
     fprintf(stderr, "Usage:\n");
     fprintf(stderr, "  ./statsd-proxy -f ./path/to/config.cfg\n");
     fprintf(stderr, "Options:\n");
-    fprintf(stderr, "  -h, --help        Show this message\n");
-    fprintf(stderr, "  -v, --version     Show version\n");
-    fprintf(stderr, "  -d, --debug       Enable debug logging\n");
+    fprintf(stderr, "  -h, --help            Show this message\n");
+    fprintf(stderr, "  -v, --version         Show version\n");
+    fprintf(stderr, "  -d, --debug           Enable debug logging\n");
+    fprintf(stderr, "  -p, --preagg agg.fg   Preagg config file\n");
     fprintf(stderr, "Copyright (c) https://github.com/hit9/statsd-proxy\n");
     exit(1);
 }


### PR DESCRIPTION
添加了指标替换的功能：
目的 agg.cfg 所示， 首先匹配以  `metric.test.v` 为开头的所有metric，例如 `metric.test.value-xg-1.do`和 `metric.test.visual` ，然后，从匹配位置开始截取到下一个 `.` 符号为止，全部替换成 `metric.test.hello` 。
最终结果就是:  
`metric.test.hello.do`  
`metric.test.hello`
