### PR TITLE
add feature to customize SO_RCVBUF size to socket.

### DIFF
--- a/example.cfg
+++ b/example.cfg
@@ -1,6 +1,7 @@
 port 8125
 num_threads 4
 flush_interval 10  # ms
+socket_receive_bufsize 106496
 
 node 127.0.0.1:8126:1
 node 127.0.0.1:8127:1

--- a/src/config.c
+++ b/src/config.c
@@ -22,6 +22,7 @@ struct config *config_new(void) {
     c->port = 8125;
     c->num_threads = 4;
     c->flush_interval = 10;
+    c->socket_receive_bufsize = 0;
 
     int i;
 
@@ -127,6 +128,18 @@ int config_init(struct config *c, const char *filename) {
 
             c->flush_interval = (uint32_t)flush_interval;
             log_debug("load config.flush_interval => %ldms", c->flush_interval);
+        }
+
+        if (strncmp("socket_receive_bufsize", cfg.key, cfg.key_len) == 0) {
+            long socket_receive_bufsize = strtol(s, NULL, 10);
+
+            if (socket_receive_bufsize <= 0) {
+                log_error("invalid socket_receive_bufsize at line %d", cfg.lineno);
+                return CONFIG_EVALUE;
+            }
+
+            c->socket_receive_bufsize = socket_receive_bufsize;
+            log_debug("load config.socket_receive_bufsize => %ld", c->socket_receive_bufsize);
         }
 
         if (strncmp("node", cfg.key, cfg.key_len) == 0) {

--- a/src/config.h
+++ b/src/config.h
@@ -28,6 +28,7 @@ struct config {
     unsigned short num_threads;
     size_t num_nodes;
     uint32_t flush_interval;
+    long socket_receive_bufsize;
     struct ketama_node nodes[KETAMA_NUM_NODES_MAX];
 };
 

--- a/src/ctx.h
+++ b/src/ctx.h
@@ -4,6 +4,11 @@
  * Proxy thread context.
  */
 
+
+#ifndef KERNEL_ADDED_OVERHEAD_FACTOR
+#define KERNEL_ADDED_OVERHEAD_FACTOR 2  // socket(7) man page indicates that the kernel doubles the size of SO_RCVBUF when set by setsockopt()
+#endif
+
 #ifndef _CW_CTX_H
 #define _CW_CTX_H 1
 
@@ -28,6 +33,7 @@ struct ctx {
     int sfd;                 /* server udp socket fd */
     unsigned short port;     /* server port to bind */
     uint32_t flush_interval; /* buffer flush interval */
+    long socket_receive_bufsize; /* socket receive buffer size in bytes */
     size_t num_nodes;        /* number of ketama nodes */
     struct ketama_node *
         nodes; /* ketama nodes ref (shared by multiple threads, read only) */
@@ -38,7 +44,7 @@ struct ctx {
 };
 
 struct ctx *ctx_new(struct ketama_node *nodes, size_t num_nodes,
-                    unsigned short port, uint32_t flush_interval);
+                    unsigned short port, uint32_t flush_interval, long socket_receive_bufsize);
 void ctx_free(struct ctx *ctx);
 int ctx_init(struct ctx *ctx);
 

--- a/src/statsd-proxy.c
+++ b/src/statsd-proxy.c
@@ -106,7 +106,7 @@ void start(struct config *config) {
 
     for (i = 0; i < config->num_threads; i++) {
         if ((ctxs[i] = ctx_new(config->nodes, config->num_nodes, config->port,
-                               config->flush_interval)) == NULL)
+                               config->flush_interval, config->socket_receive_bufsize)) == NULL)
             exit(1);
         pthread_create(&threads[i], NULL, &thread_start, ctxs[i]);
     }


### PR DESCRIPTION
This enables statsd-proxy to manage SO_RCVBUF independent of system-wide rmem_default.