### PR TITLE
add feature to configure socket send packet size #17

### DIFF
--- a/example.cfg
+++ b/example.cfg
@@ -2,6 +2,7 @@ port 8125
 num_threads 4
 flush_interval 10  # ms
 socket_receive_bufsize 106496
+#socket_send_packet_size 8192
 
 node 127.0.0.1:8126:1
 node 127.0.0.1:8127:1

--- a/src/config.c
+++ b/src/config.c
@@ -13,6 +13,7 @@
 #include "cfg.h"
 #include "config.h"
 #include "log.h"
+#include "proxy.h"
 
 struct config *config_new(void) {
     struct config *c = malloc(sizeof(struct config));
@@ -23,6 +24,7 @@ struct config *config_new(void) {
     c->num_threads = 4;
     c->flush_interval = 10;
     c->socket_receive_bufsize = 0;
+    c->socket_send_packet_size = BUF_SEND_UNIT;
 
     int i;
 
@@ -140,6 +142,18 @@ int config_init(struct config *c, const char *filename) {
 
             c->socket_receive_bufsize = socket_receive_bufsize;
             log_debug("load config.socket_receive_bufsize => %ld", c->socket_receive_bufsize);
+        }
+
+        if (strncmp("socket_send_packet_size", cfg.key, cfg.key_len) == 0) {
+            uint32_t socket_send_packet_size = strtol(s, NULL, 10);
+
+            if (socket_send_packet_size <= 0) {
+                log_error("invalid socket_send_packet_size at line %d", cfg.lineno);
+                return CONFIG_EVALUE;
+            }
+
+            c->socket_send_packet_size = socket_send_packet_size;
+            log_debug("load config.socket_send_packet_size => %ld", c->socket_send_packet_size);
         }
 
         if (strncmp("node", cfg.key, cfg.key_len) == 0) {

--- a/src/config.h
+++ b/src/config.h
@@ -29,6 +29,7 @@ struct config {
     size_t num_nodes;
     uint32_t flush_interval;
     long socket_receive_bufsize;
+    uint32_t socket_send_packet_size;
     struct ketama_node nodes[KETAMA_NUM_NODES_MAX];
 };
 

--- a/src/ctx.c
+++ b/src/ctx.c
@@ -20,7 +20,7 @@
 
 /* Create ctx, init client/server sockets and ketama ring. */
 struct ctx *ctx_new(struct ketama_node *nodes, size_t num_nodes,
-                    unsigned short port, uint32_t flush_interval, long socket_receive_bufsize) {
+                    unsigned short port, uint32_t flush_interval, long socket_receive_bufsize, uint32_t socket_send_packet_size) {
     assert(nodes != NULL);
 
     /* Create ctx */
@@ -93,6 +93,7 @@ struct ctx *ctx_new(struct ketama_node *nodes, size_t num_nodes,
     ctx->num_nodes = num_nodes;
     ctx->flush_interval = flush_interval;
     ctx->socket_receive_bufsize = socket_receive_bufsize;
+    ctx->socket_send_packet_size = socket_send_packet_size;
     return ctx;
 }
 

--- a/src/ctx.h
+++ b/src/ctx.h
@@ -34,6 +34,7 @@ struct ctx {
     unsigned short port;     /* server port to bind */
     uint32_t flush_interval; /* buffer flush interval */
     long socket_receive_bufsize; /* socket receive buffer size in bytes */
+    uint32_t socket_send_packet_size; /* socket send packet size in bytes */
     size_t num_nodes;        /* number of ketama nodes */
     struct ketama_node *
         nodes; /* ketama nodes ref (shared by multiple threads, read only) */
@@ -44,7 +45,7 @@ struct ctx {
 };
 
 struct ctx *ctx_new(struct ketama_node *nodes, size_t num_nodes,
-                    unsigned short port, uint32_t flush_interval, long socket_receive_bufsize);
+                    unsigned short port, uint32_t flush_interval, long socket_receive_bufsize, uint32_t socket_send_packet_size);
 void ctx_free(struct ctx *ctx);
 int ctx_init(struct ctx *ctx);
 

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -146,7 +146,7 @@ int relay_buf(struct ctx *ctx) {
             return PROXY_ENOMEM;
 
         /* flush buffer if this buf is large enough */
-        if (sbuf->len >= BUF_SEND_UNIT) send_buf(ctx, addr, sbuf, node->key);
+        if (sbuf->len >= ctx->socket_send_packet_size) send_buf(ctx, addr, sbuf, node->key);
 
         data += n;
         len -= n;

--- a/src/statsd-proxy.c
+++ b/src/statsd-proxy.c
@@ -106,7 +106,7 @@ void start(struct config *config) {
 
     for (i = 0; i < config->num_threads; i++) {
         if ((ctxs[i] = ctx_new(config->nodes, config->num_nodes, config->port,
-                               config->flush_interval, config->socket_receive_bufsize)) == NULL)
+                               config->flush_interval, config->socket_receive_bufsize, config->socket_send_packet_size)) == NULL)
             exit(1);
         pthread_create(&threads[i], NULL, &thread_start, ctxs[i]);
     }


### PR DESCRIPTION
make send packet size configurable.

1. large packets will be dropped as below in systems not supporting udp fragmentation.
```
02:54:27.461925 IP ip-10-1-12-216.ap-northeast-1.compute.internal.35504 > ip-10-1-13-162.ap-northeast-1.compute.internal.8125: UDP, bad length 32823 > 8968
```
2. recent ec2 instances use MTU 9001, leave 8192 commented for reference.